### PR TITLE
Add the `setDisableHeaderCheck` method from the original package

### DIFF
--- a/__tests__/test-headers.ts
+++ b/__tests__/test-headers.ts
@@ -71,6 +71,7 @@ test('headers', async (done) => {
   expect('').toEqual(xhr.getRequestHeader('Content-Length'));
 
   // Test allowing all headers
+  xhr.setDisableHeaderCheck(true);
   xhr.setRequestHeader('Referer', 'http://github.com');
 
   xhr.send(undefined);

--- a/src/XMLHttpRequest.ts
+++ b/src/XMLHttpRequest.ts
@@ -363,13 +363,11 @@ export class XMLHttpRequest {
       throw new InvalidStateDOMException('state is not opened');
     }
 
-    /*     if (!this.isAllowedHttpHeader(header)) {
-      throw new Error('Refused to set unsafe header "' + header + '"');
-    } */
     if (this.sendFlag) {
       throw new Error('INVALID_STATE_ERR: send flag is true');
     }
-    if (Headers.isForbidden(header)) {
+    if (!this.disableHeaderCheck && Headers.isForbidden(header)) {
+      console.warn(`Refused to set unsafe header "${header}"`);
       return;
     }
     header = this.headersCase[header.toLowerCase()] || header;
@@ -377,6 +375,18 @@ export class XMLHttpRequest {
     this.headers[header] = this.headers[header]
       ? this.headers[header] + ', ' + value
       : value;
+  }
+
+  private disableHeaderCheck: boolean = false
+  /**
+   * Disables or enables `Headers.isForbidden(header)` check in the `setRequestHeader`.
+   * The check is done by default (passing `false`).
+   * If you pass `true`, then it no longer conforms to the W3C spec.
+   *
+   * @param {boolean} state enable or disable header checking.
+   */
+  public setDisableHeaderCheck(state: boolean = false) {
+    this.disableHeaderCheck = state;
   }
 
   private setState(state: number): void {


### PR DESCRIPTION
Addresses https://github.com/ryanleecode/node-XMLHttpRequest/issues/21

The tests:
![image](https://user-images.githubusercontent.com/16418197/114505319-d05d4b80-9bf5-11eb-921f-8620d093053b.png)
